### PR TITLE
Fixed apparent error with << operator for MealType by adding default constructor

### DIFF
--- a/food-calc/Meal.cpp
+++ b/food-calc/Meal.cpp
@@ -21,3 +21,6 @@ meal_type_ (meal_type) {
     }
   }
 }
+
+Meal::Meal ():
+Meal(MealType::Snack) {}

--- a/food-calc/Meal.cpp
+++ b/food-calc/Meal.cpp
@@ -1,11 +1,11 @@
 #include "Meal.hpp"
 
-Meal::Meal (MealType meal_type, unsigned calories_needed):
-meal_type_(meal_type),
-calories_needed_(calories_needed) {}
+Meal::Meal (const MealType &meal_type, const unsigned &calories_needed):
+meal_type_ (meal_type),
+calories_needed_ (calories_needed) {}
 
-Meal::Meal (MealType meal_type):
-meal_type_(meal_type) {
+Meal::Meal (const MealType &meal_type):
+meal_type_ (meal_type) {
   switch (meal_type) { // assigns default amount of calories for meal based on meal type
     case MealType::Breakfast: {
       calories_needed_ = 600;

--- a/food-calc/Meal.hpp
+++ b/food-calc/Meal.hpp
@@ -1,7 +1,7 @@
 #ifndef MEAL_HPP
 #define MEAL_HPP
 
-#include <iostream>
+#include <string>
 #include <vector>
 
 enum class MealType {Breakfast, Lunch, Dinner, Snack};
@@ -10,6 +10,44 @@ struct FoodItem {
   std::string name;
   std::string cals; // later versions of program could take more nutrition facts into account
 };
+
+// Helper functions:
+namespace {
+  /**
+    Converts meal type into string.
+
+    @param meal_type Meal type to be converted to stream.
+    @return Meal type converted to string.
+  */
+  std::string MealStringify (const MealType &meal_type) {
+    switch (meal_type) {
+      case MealType::Breakfast: {
+        return "Breakfast";
+      } break;
+      case MealType::Lunch: {
+        return "Lunch";
+      } break;
+      case MealType::Dinner: {
+        return "Dinner";
+      } break;
+      default: { // includes Snack meal type
+        return "Snack";
+      }
+    }
+  }
+  /**
+    Outputs meal type to output stream.
+
+    @param os Output stream.
+    @param meal_type Meal type to be output as string.
+    @return Output stream.
+  */
+  std::ostream& operator<< (std::ostream& os, const MealType &meal_type) {
+    os << MealStringify(meal_type);
+
+    return os;
+  }
+}
 
 class Meal {
 private:
@@ -89,33 +127,5 @@ public:
   */
   void set_food (const std::vector<FoodItem> &food) { food_ = food; }
 };
-
-namespace {
-  /**
-    Outputs meal type to output stream.
-
-    @param os Output stream.
-    @param meal_type Meal type to be output as string.
-    @return Output stream.
-  */
-  std::ostream& operator<< (std::ostream& os, const MealType &meal_type) {
-    switch (meal_type) {
-      case MealType::Breakfast: {
-        os << "Breakfast";
-      } break;
-      case MealType::Lunch: {
-        os << "Lunch";
-      } break;
-      case MealType::Dinner: {
-        os << "Dinner";
-      } break;
-      default: { // includes Snack meal type
-        os << "Snack";
-      }
-    }
-
-    return os;
-  }
-}
 
 #endif // MEAL_HPP

--- a/food-calc/Meal.hpp
+++ b/food-calc/Meal.hpp
@@ -1,4 +1,7 @@
-#include <string>
+#ifndef MEAL_HPP
+#define MEAL_HPP
+
+#include <iostream>
 #include <vector>
 
 enum class MealType {Breakfast, Lunch, Dinner, Snack};
@@ -22,7 +25,7 @@ public:
     @param calories_needed Amount of calories meal should have.
     @return Foodless Meal of type meal_type with calories_needed expected calories.
   */
-  Meal (MealType meal_type, unsigned calories_needed);
+  Meal (const MealType &meal_type, const unsigned &calories_needed);
 
   /**
     Instantiates foodless Meal of type meal_type with default number of calories for given meal type.
@@ -30,7 +33,7 @@ public:
     @param meal_type Type of meal (breakfast, lunch, dinner, snack).
     @return Foodless Meal of type meal_type with default number of calories for given meal type.
   */
-  Meal (MealType meal_type);
+  Meal (const MealType &meal_type);
 
   /**
     Default constructor, instantiates a zero calorie foodless snack.
@@ -42,5 +45,77 @@ public:
   /**
     Class destructor, clears all dynamically allocated memory of instance of class.
   */
-  virtual ~Meal ();
+  //virtual ~Meal ();
+
+  /**
+    Returns type of Meal object.
+
+    @return Type of Meal object.
+  */
+  MealType get_meal_type () { return meal_type_; } const
+
+  /**
+    Returns expected calories for meal.
+
+    @return Expected calories for meal.
+  */
+  unsigned get_calories_needed () { return calories_needed_; } const
+
+  /**
+    Returns vector of food items in meal.
+
+    @return Vector of food items in meal.
+  */
+  std::vector<FoodItem> get_food () { return food_; } const
+
+  /**
+    Sets meal_type_ field to meal_type.
+
+    @param meal_type Meal type to set meal_type_ field to.
+  */
+  void set_meal_type (const MealType &meal_type) { meal_type_ = meal_type; }
+
+  /**
+    Sets calories_needed_ field to calories_needed.
+
+    @param calories_needed Expected calories to set calories_needed_ field to.
+  */
+  void set_calories_needed (const unsigned &calories_needed) { calories_needed_ = calories_needed; }
+
+  /**
+    Sets food_ field to food.
+
+    @param food Vector of food items to set food_ field to.
+  */
+  void set_food (const std::vector<FoodItem> &food) { food_ = food; }
 };
+
+namespace {
+  /**
+    Outputs meal type to output stream.
+
+    @param os Output stream.
+    @param meal_type Meal type to be output as string.
+    @return Output stream.
+  */
+  std::ostream& operator<< (std::ostream& os, const MealType &meal_type) {
+    switch (meal_type) {
+      case MealType::Breakfast: {
+        os << "Breakfast";
+      } break;
+      case MealType::Lunch: {
+        os << "Lunch";
+      } break;
+      case MealType::Dinner: {
+        os << "Dinner";
+      } break;
+      default: { // includes Snack meal type
+        os << "Snack";
+      }
+    }
+
+    return os;
+  }
+}
+
+#endif // MEAL_HPP

--- a/food-calc/main.cpp
+++ b/food-calc/main.cpp
@@ -8,6 +8,8 @@
 #include "Meal.hpp"
 
 int main(int argc, char const *argv[]) {
-  /* code */
+  Meal test;
+
+  std::cout << test.get_meal_type() << ' ' << test.get_calories_needed() << std::endl;
   return 0;
 }

--- a/food-calc/main.cpp
+++ b/food-calc/main.cpp
@@ -6,6 +6,7 @@
 */
 
 #include "Meal.hpp"
+#include <iostream>
 
 int main(int argc, char const *argv[]) {
   Meal test;


### PR DESCRIPTION
I said "apparent" because the error was not actually with the << operator, but with the fact that I was calling a default constructor that didn't exist and causing a linker error. I had assumed the linker error was caused by operator<< not linking properly, but this was not the case.